### PR TITLE
feat: add about/version commands and fix dynamic /api/commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,6 +169,19 @@ Usage:
 🦴 Complexity is the enemy.`;
     },
 
+
+    about() {
+        return `🦴 grugbot420 v${this.version}
+A neuromorphic AI engine built the grug way.
+Zero dependencies. Just works.
+GitHub: https://github.com/grug-group420/grugbot420
+Portal: https://grug-group420.github.io/portal`;
+    },
+
+    version() {
+        return `grugbot420 v${this.version}`;
+    },
+
     // Process text commands (for CLI/chat)
     process(input) {
         const cmd = (input || '').toLowerCase().trim();
@@ -184,6 +197,8 @@ Usage:
             review: () => this.review(),
             standup: () => this.standup(),
             motivation: () => this.motivation(),
+            about: () => this.about(),
+            version: () => this.version(),
             help: () => this.help()
         };
         return commands[cmd] ? commands[cmd]() : this.help();

--- a/server/index.ts
+++ b/server/index.ts
@@ -116,12 +116,12 @@ const server = Bun.serve({
       });
     }
     
-    // API: List all commands
+    // API: List all commands (dynamic from bot)
     if (path === '/api/commands') {
-      return json({
-        commands: ['help', 'wisdom', 'ship', 'think', 'debug', 'complexity', 'joke', 'coffee'],
-        version: grugbot.version
-      });
+      const commands = Object.keys(grugbot).filter(
+        k => typeof grugbot[k] === 'function' && !['random', 'process'].includes(k)
+      );
+      return json({ commands, version: grugbot.version });
     }
     
     // Serve portal


### PR DESCRIPTION
## Summary

- **`about`** command: returns project info + links (GitHub, Portal)
- **`version`** command: returns current version string
- **`/api/commands` fix**: the endpoint was returning a hardcoded 8-item list that was missing `yeet`, `review`, `standup`, `motivation`, `about`, and `version`. Now it reads command names dynamically from the bot object so it never goes stale.

## Changes
- `index.js`: added `about()` and `version()` methods + registered in `process()`
- `server/index.ts`: `/api/commands` now reflects all commands dynamically

🦴 Less hardcoding. More shipping.